### PR TITLE
README: add tap creation command in native2os

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ native2os
 ---------
 Some of these tests use a tap interface to communicate between a native RIOT instance and the Linux desktop. They require an fd00:bbbb::/64 ULA-based network defined on the desktop as:
 ```
+    $ sudo ip tuntap add tap0 mode tap user ${USER}
+    $ sudo ip link set tap0 up
     $ sudo ip address add fd00:bbbb::1/64 dev tap0 scope global
 ```
 


### PR DESCRIPTION
This adds to the `README` the setup for the tap interface, I might be evident but at first I was creating them with `sudo ~/workspace/RIOT/dist/tools/tapsetup/tapsetup -c 1` but that doesn't work out of the box since the script does some different configurations.